### PR TITLE
RFC: NOINLINE fromString

### DIFF
--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -165,6 +165,7 @@ instance Monoid (Doc a) where
 
 instance HasChars a => IsString (Doc a) where
   fromString = text
+  {-# NOINLINE fromString #-}
 
 -- | Unfold a 'Doc' into a flat list.
 unfoldD :: Doc a -> [Doc a]


### PR DESCRIPTION
While investigating GHC's compiler performance on `pandoc` in https://gitlab.haskell.org/ghc/ghc/-/issues/18010, I noticed that in some of the `Writers` modules, overloaded `Doc Text` literals resulted in fairly large amounts of Core that includes the `text` internals used in the `fromString` implementation.

By preventing `fromString` from inlining, total allocations for building `pandoc-2.12` with GHC 8.10.4 are reduced by 8.5% and peak allocations are reduced from 3854MB to 3389MB on my machine.