### PR TITLE
NOINLINE `literal` instead of `fromString`

### DIFF
--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -165,7 +165,6 @@ instance Monoid (Doc a) where
 
 instance HasChars a => IsString (Doc a) where
   fromString = text
-  {-# NOINLINE fromString #-}
 
 -- | Unfold a 'Doc' into a flat list.
 unfoldD :: Doc a -> [Doc a]
@@ -489,6 +488,7 @@ literal x =
                     then Empty
                     else Text (realLength s) s) $
         splitLines x
+{-# NOINLINE literal #-}
 
 -- | A literal string.  (Like 'literal', but restricted to String.)
 text :: HasChars a => String -> Doc a


### PR DESCRIPTION
`literal` contributes most of the `text` Core to `fromString`,
but it's also used directly in the pandoc codebase and in `renderDoc`.

Therefore this patch reduces total compile time allocations for
pandoc-2.12 with ghc-8.10.4 by another 17% on top of the improvements
from 7a23715f10fe20f1cd4d0a35a1fc57c2268d261f.

This patch also affects the runtime performance of pandoc's
writers, both positively and negatively:

On my machine, the affected benchmarks are:

      writers
        context:               FAIL (0.39s)
          6.9 ms ± 446 μs, 21% faster than baseline
        docx:                  FAIL (2.69s)
           84 ms ± 3.7 ms, 18% slower than baseline
        dokuwiki:              FAIL (0.90s)
          5.5 ms ± 187 μs, 27% slower than baseline
        markdown:              FAIL (1.12s)
           15 ms ± 184 μs, 16% slower than baseline
        native:                FAIL (0.36s)
          2.5 ms ± 195 μs, 10% faster than baseline
        xwiki:                 FAIL (0.28s)
          3.7 ms ± 366 μs, 20% faster than baseline

    6 out of 85 tests failed (40.79s)