### PR TITLE
Fix the end of the block of zero width characters which contains the

### DIFF
--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -832,7 +832,7 @@ unicodeRangeMap = IM.fromList $ map (\(c, x) -> (ord c, x))
     , ('\x1DC0', RangeSeparator 0)  -- combining
     , ('\x1E00', RangeSeparator 1)
     , ('\x200B', RangeSeparator 0)  -- zero-width characters and directional overrides
-    , ('\x2030', RangeSeparator 1)  -- combining
+    , ('\x2010', RangeSeparator 1)
     , ('\x20D0', RangeSeparator 0)  -- combining
     , ('\x2100', RangeSeparator 1)
     , ('\x2329', RangeSeparator 2)


### PR DESCRIPTION
zero-width joiners and directional markings.