### PR TITLE
Test that taking shortcuts in realLength works in a wide context as well

### DIFF
--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -71,7 +71,9 @@ module Text.DocLayout (
      , realLength
      , realLengthNarrowContext
      , realLengthWideContext
-     , realLengthNoShortcut
+     , realLengthWith
+     , updateMatchStateNoShortcut
+     , resolveWidth
      , isSkinToneModifier
      , isEmojiVariation
      , isEmojiJoiner
@@ -705,13 +707,6 @@ realLengthNarrowContext = realLengthWith . updateMatchState $ resolveWidth 1
 realLengthWideContext :: HasChars a => a -> Int
 realLengthWideContext = realLengthWith . updateMatchState $ resolveWidth 2
 
--- | Get real length of string, taking into account combining and double-wide
--- characters, without taking any shortcuts. This should give the same answer
--- as 'updateMatchState', but will be slower. It is here to test that the
--- shortcuts are implemented correctly. Ambiguous characters are treated as width 1.
-realLengthNoShortcut :: HasChars a => a -> Int
-realLengthNoShortcut = realLengthWith . updateMatchStateNoShortcut $ resolveWidth 1
-
 -- | Resolve ambiguous characters based on their context.
 resolveWidth :: Int -> UnicodeWidth -> Int
 resolveWidth _ Narrow    = 1
@@ -721,7 +716,7 @@ resolveWidth _ Control   = 0
 resolveWidth c Ambiguous = c
 
 -- | Get real length of string, taking into account combining and double-wide
--- characters, using the given accumulator.
+-- characters, using the given accumulator. This is exposed for testing.
 realLengthWith :: HasChars a => (MatchState -> Char -> MatchState) -> a -> Int
 realLengthWith f = extractLength . foldlChar f (MatchState True 0 False 0 mempty)
   where

--- a/test/test.hs
+++ b/test/test.hs
@@ -312,6 +312,9 @@ tests =
   , testGroup "all zero-width joiner emoji sequences have width 2" $
       zwjEmojis <&> \emoji -> testCase (T.unpack emoji) $ realLength emoji @?= 2
 
-  , testProperty "shortcut provides same answer for string length" . withMaxSuccess 1000000 $
-      \(x :: String) -> realLength x === realLengthNoShortcut x
+  , testProperty "shortcut provides same answer for string length in a narrow context" . withMaxSuccess 1000000 $
+      \(x :: String) -> realLengthNarrowContext x === realLengthWith (updateMatchStateNoShortcut (resolveWidth 1)) x
+
+  , testProperty "shortcut provides same answer for string length in a wide context" . withMaxSuccess 1000000 $
+      \(x :: String) -> realLengthWideContext x === realLengthWith (updateMatchStateNoShortcut (resolveWidth 2)) x
   ]


### PR DESCRIPTION
as a narrow context.

Implement some speedups for ascii text.