### PR TITLE
Improve performance of realLength

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -32,7 +32,7 @@ main = do
     udhrThj <- udhrLang "thj"
     udhrGrk <- udhrLang "grk"
     emojiTxt <- evaluate . force . T.replicate 1000 $ mconcat baseEmojis <> mconcat zwjEmojis
-    defaultMainWith defaultConfig{ timeLimit = 10.0 } $
+    defaultMainWith defaultConfig{ timeLimit = 5.0 } $
       [ bench "sample document 2" $
           nf (render Nothing :: Doc Text -> Text)
              (nest 3 $ cblock 20 $ vcat $ replicate 15 $

--- a/test/test.hs
+++ b/test/test.hs
@@ -313,7 +313,7 @@ tests =
       zwjEmojis <&> \emoji -> testCase (T.unpack emoji) $ realLength emoji @?= 2
 
   , testProperty "shortcut provides same answer for string length in a narrow context" . withMaxSuccess 1000000 $
-      \(x :: String) -> realLengthNarrowContext x === realLengthWith updateMatchStateNoShortcutNarrow x
+      \(x :: String) -> realLengthNarrowContext x === realLengthWith updateMatchStateNoShortcut x
 
   , testProperty "shortcut provides same answer for string length in a wide context" . withMaxSuccess 1000000 $
       \(x :: String) -> realLengthWideContext x === realLengthWith updateMatchStateNoShortcutWide x


### PR DESCRIPTION
This improves the performance of the NoShortcut part of `realLength`, using a more easily optimised data structure, and carries around less emoji information.