### PR TITLE
Introduce support for styling documents with ANSI codes

### DIFF
--- a/doclayout.cabal
+++ b/doclayout.cabal
@@ -24,6 +24,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Text.DocLayout
+  other-modules:       Text.DocLayout.HasChars
   build-depends:       base >= 4.12 && < 5,
                        text,
                        containers,

--- a/doclayout.cabal
+++ b/doclayout.cabal
@@ -24,7 +24,9 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Text.DocLayout
-  other-modules:       Text.DocLayout.HasChars
+  other-modules:       Text.DocLayout.HasChars,
+                       Text.DocLayout.ANSIFont,
+                       Text.DocLayout.Attributed
   build-depends:       base >= 4.12 && < 5,
                        text,
                        containers,

--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -102,53 +102,14 @@ import qualified Data.Map.Internal as MInt
 import Data.Data (Data, Typeable)
 import Data.String
 import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
 import Data.Text (Text)
+import Text.DocLayout.HasChars
 #if MIN_VERSION_base(4,11,0)
 #else
 import Data.Semigroup
 #endif
 import Text.Emoji (baseEmojis)
 
-
--- | Class abstracting over various string types that
--- can fold over characters.  Minimal definition is 'foldrChar'
--- and 'foldlChar', but defining the other methods can give better
--- performance.
-class (IsString a, Semigroup a, Monoid a, Show a) => HasChars a where
-  foldrChar     :: (Char -> b -> b) -> b -> a -> b
-  foldlChar     :: (b -> Char -> b) -> b -> a -> b
-  replicateChar :: Int -> Char -> a
-  replicateChar n c = fromString (replicate n c)
-  isNull        :: a -> Bool
-  isNull = foldrChar (\_ _ -> False) True
-  splitLines    :: a -> [a]
-  splitLines s = (fromString firstline : otherlines)
-   where
-    (firstline, otherlines) = foldrChar go ([],[]) s
-    go '\n' (cur,lns) = ([], fromString cur : lns)
-    go c    (cur,lns) = (c:cur, lns)
-
-instance HasChars Text where
-  foldrChar         = T.foldr
-  foldlChar         = T.foldl'
-  splitLines        = T.splitOn "\n"
-  replicateChar n c = T.replicate n (T.singleton c)
-  isNull            = T.null
-
-instance HasChars String where
-  foldrChar     = foldr
-  foldlChar     = foldl'
-  splitLines    = lines . (++"\n")
-  replicateChar = replicate
-  isNull        = null
-
-instance HasChars TL.Text where
-  foldrChar         = TL.foldr
-  foldlChar         = TL.foldl'
-  splitLines        = TL.splitOn "\n"
-  replicateChar n c = TL.replicate (fromIntegral n) (TL.singleton c)
-  isNull            = TL.null
 
 -- | Document, including structure relevant for layout.
 data Doc a = Text Int a            -- ^ Text with specified width.

--- a/src/Text/DocLayout/ANSIFont.hs
+++ b/src/Text/DocLayout/ANSIFont.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+module Text.DocLayout.ANSIFont
+  ( Font(..)
+  , baseFont
+  , StyleReq(..)
+  , Weight(..)
+  , Shape(..)
+  , Color8(..)
+  , Underline(..)
+  , Foreground(..)
+  , Background(..)
+  , (~>)
+  , renderFont
+  ) where
+
+import Data.Data (Data)
+import Data.String
+
+data Font = Font
+  { ftWeight :: Weight,
+    ftShape :: Shape,
+    ftUnderline :: Underline,
+    ftForeground :: Foreground,
+    ftBackground :: Background
+  }
+  deriving (Show, Eq, Read, Data, Ord)
+
+baseFont :: Font
+baseFont = Font Normal Roman ULNone FGDefault BGDefault
+
+data Weight = Normal | Bold deriving (Show, Eq, Read, Data, Ord)
+data Shape = Roman | Italic deriving (Show, Eq, Read, Data, Ord)
+data Color8 = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White deriving (Show, Eq, Enum, Read, Data, Ord)
+data Underline = ULNone | ULSingle | ULDouble | ULCurly deriving (Show, Eq, Read, Data, Ord)
+data Foreground = FGDefault | FG Color8 deriving (Show, Eq, Read, Data, Ord)
+data Background = BGDefault | BG Color8 deriving (Show, Eq, Read, Data, Ord)
+
+data StyleReq =
+  RWeight Weight | RShape Shape | RForeground Foreground | RBackground Background | RUnderline Underline
+  deriving (Show, Eq, Read, Data, Ord)
+
+(~>) :: Font -> StyleReq -> Font
+(~>) f (RWeight w) = f{ftWeight = w}
+(~>) f (RShape s) = f{ftShape = s}
+(~>) f (RForeground c) = f{ftForeground = c}
+(~>) f (RBackground c) = f{ftBackground = c}
+(~>) f (RUnderline u) = f{ftUnderline = u}
+
+rawSGR :: (Semigroup a, IsString a) => a -> a
+rawSGR n = "\ESC[" <> n <> "m"
+
+class SGR b where
+  renderSGR :: (Semigroup a, IsString a) => b -> a
+
+instance SGR Weight where
+  renderSGR Normal = rawSGR "22"
+  renderSGR Bold = rawSGR "1"
+
+instance SGR Shape where
+  renderSGR Roman = rawSGR "23"
+  renderSGR Italic = rawSGR "3"
+
+instance SGR Foreground where
+  renderSGR FGDefault = rawSGR "39"
+  renderSGR (FG a) = (rawSGR . fromString . show . (+) 30 . fromEnum) a
+
+instance SGR Background where
+  renderSGR BGDefault = rawSGR "49"
+  renderSGR (BG a) = (rawSGR . fromString . show . (+) 40 . fromEnum) a
+
+instance SGR Underline where
+  renderSGR ULNone = rawSGR "24"
+  renderSGR ULSingle = rawSGR "4"
+  renderSGR ULDouble = rawSGR "21"
+  renderSGR ULCurly = rawSGR "4:3"
+
+renderFont :: (Semigroup a, IsString a) => Font -> a
+renderFont f
+  | f == baseFont = rawSGR "0"
+  | otherwise =
+      renderSGR (ftWeight f)
+        <> renderSGR (ftShape f)
+        <> renderSGR (ftForeground f)
+        <> renderSGR (ftBackground f)
+        <> renderSGR (ftUnderline f)

--- a/src/Text/DocLayout/Attributed.hs
+++ b/src/Text/DocLayout/Attributed.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+module Text.DocLayout.Attributed (Attributed(..))
+  where
+
+import Data.String
+import Text.DocLayout.ANSIFont (Font, baseFont)
+import Data.Data (Data, Typeable)
+import GHC.Generics
+
+data Attributed a = Attr Font a
+                  | Concattr (Attributed a) (Attributed a)
+                  | Null
+  deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable,
+          Data, Typeable, Generic)
+
+instance Semigroup a => Semigroup (Attributed a) where
+  (<>) a@(Attr f1 x1) b@(Attr f2 x2)
+    | f1 == f2  = Attr f1 (x1 <> x2)
+    | otherwise = Concattr a b
+  (<>) (Concattr a b) c = Concattr a (b <> c)
+  (<>) a@(Attr _ _) (Concattr b c) = Concattr (a <> b) c
+  (<>) Null b = b
+  (<>) a Null = a
+
+instance Monoid a => Monoid (Attributed a) where
+  mempty = Null
+
+instance IsString a => IsString (Attributed a) where
+  fromString x | null x = Null
+               | otherwise = Attr baseFont (fromString x)

--- a/src/Text/DocLayout/HasChars.hs
+++ b/src/Text/DocLayout/HasChars.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE MultiWayIf         #-}
+{-# LANGUAGE NoImplicitPrelude  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+module Text.DocLayout.HasChars (HasChars(..)) where
+import Prelude
+import Data.String
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Data.Text (Text)
+import Data.List (foldl')
+
+-- | Class abstracting over various string types that
+-- can fold over characters.  Minimal definition is 'foldrChar'
+-- and 'foldlChar', but defining the other methods can give better
+-- performance.
+class (IsString a, Semigroup a, Monoid a, Show a) => HasChars a where
+  foldrChar     :: (Char -> b -> b) -> b -> a -> b
+  foldlChar     :: (b -> Char -> b) -> b -> a -> b
+  replicateChar :: Int -> Char -> a
+  replicateChar n c = fromString (replicate n c)
+  isNull        :: a -> Bool
+  isNull = foldrChar (\_ _ -> False) True
+  splitLines    :: a -> [a]
+  splitLines s = (fromString firstline : otherlines)
+   where
+    (firstline, otherlines) = foldrChar go ([],[]) s
+    go '\n' (cur,lns) = ([], fromString cur : lns)
+    go c    (cur,lns) = (c:cur, lns)
+
+instance HasChars Text where
+  foldrChar         = T.foldr
+  foldlChar         = T.foldl'
+  splitLines        = T.splitOn "\n"
+  replicateChar n c = T.replicate n (T.singleton c)
+  isNull            = T.null
+
+instance HasChars String where
+  foldrChar     = foldr
+  foldlChar     = foldl'
+  splitLines    = lines . (++"\n")
+  replicateChar = replicate
+  isNull        = null
+
+instance HasChars TL.Text where
+  foldrChar         = TL.foldr
+  foldlChar         = TL.foldl'
+  splitLines        = TL.splitOn "\n"
+  replicateChar n c = TL.replicate (fromIntegral n) (TL.singleton c)
+  isNull            = TL.null


### PR DESCRIPTION
This PR introduces support for styling and rendering Docs with ANSI terminal control codes. The public interface uses smart constructors like “bold”, “italic”, and “underlined” to apply font styling to inner Docs. The implementation grows multiple new concepts to deal with this while still supporting the prerendering of Block elements.

# ANSIFont

The ANSIFont module introduces ADTs for various text properties that are supported by terminals, and for Fonts that indicate all the properties that should apply to a particular span of text. New fonts can be constructed by applying a StyleReq to an existing font, which replaces the requested property in the original font with the requested value.

# Attributed

The Attributed model introduces Attributed strings, which carry a Font along with an inner string type. It instantiates the HasChars class so that various features of the existing DocLayout code can somewhat seamlessly support rendering styled text.

# Building and rendering styled documents

Implementation outline:

1.  Consumers add a smart constructor like `bold` to style a Doc. The inner doc gets wrapped in Doc’s `Styled` constructor, indicating the text style requested for that block.
2.  The renderer maintains a stack of `Font`s. When a `Styled` element is encountered, its `StyleReq` is applied to the `Font` on the top of the stack and pushed, the inner document is rendered, and then the font is popped and rendering continues.
3.  The `Attributed a` returned by `prerender` can be rendered to `a` using `renderPlain`, which ignores all the font requests, or `renderANSI`, which adds the requisite control sequences to set the font every time the font changes.

Conceptually, the renderer from `Doc a` to `Attributed a` turns the nested styling requests into a linear structure where every span of text carries the full set of font attributes it should be rendered with.

The most interesting wrinkle to this implementation is that the contents of `Block` elements need to be prerendered by the `block` helper so they can be broken up into lines and filled, but we want to defer the decision of rendering plain text or ANSI-styled text until the final document is rendered. To support this, the `Block` constructor for a `Doc a` now carries an `Attributed a` in its lines field. Once the next rendering pass merges blocks together, instead of using `literal` to construct `Text` elements carring an `a` to render, it uses `cook` to construct `Cooked` elements with an `Attributed a` to be copied directly to the output stream *without looking at the font stack*. This means that the contents of a block are only ever styled by style requests that were made in the inner document of the block: the contents of `bold $ cblock n $ literal "x"` will be printed in plain text, whereas the contents of `cblock n $ bold $ literal "x"` will be bold.
