### PR TITLE
Colors, links, and strikeout

### DIFF
--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -59,6 +59,7 @@ module Text.DocLayout (
      , bold
      , italic
      , underlined
+     , strikeout
      , fg
      , bg
      , Color
@@ -786,6 +787,9 @@ italic = styled (RShape Italic)
 
 underlined :: HasChars a => Doc a -> Doc a
 underlined = styled (RUnderline ULSingle)
+
+strikeout :: HasChars a => Doc a -> Doc a
+strikeout = styled (RStrikeout Struck)
 
 -- The Color type is here as an opaque alias to Color8 for the public interface
 -- and there's trivial smart constructors for the individual colors to

--- a/src/Text/DocLayout.hs
+++ b/src/Text/DocLayout.hs
@@ -59,6 +59,17 @@ module Text.DocLayout (
      , bold
      , italic
      , underlined
+     , fg
+     , bg
+     , Color
+     , black
+     , red
+     , green
+     , yellow
+     , blue
+     , magenta
+     , cyan
+     , white
      , empty
      -- * Functions for concatenating documents
      , (<+>)
@@ -756,6 +767,43 @@ italic = styled (RShape Italic)
 
 underlined :: HasChars a => Doc a -> Doc a
 underlined = styled (RUnderline ULSingle)
+
+-- The Color type is here as an opaque alias to Color8 for the public interface
+-- and there's trivial smart constructors for the individual colors to
+-- hopefully allow for easier extension to supporting indexed and rgb colors in
+-- the future, without dramatically changing the public API.
+
+type Color = Color8
+
+fg :: HasChars a => Color -> Doc a -> Doc a
+fg = styled . RForeground . FG
+
+bg :: HasChars a => Color -> Doc a -> Doc a
+bg = styled . RBackground . BG
+
+blue :: Color
+blue = Blue
+
+black :: Color
+black = Black
+
+red :: Color
+red = Red
+
+green :: Color
+green = Green
+
+yellow :: Color
+yellow = Yellow
+
+magenta :: Color
+magenta = Magenta
+
+cyan :: Color
+cyan = Cyan
+
+white :: Color
+white = White
 
 -- | Returns width of a character in a monospace font:  0 for a combining
 -- character, 1 for a regular character, 2 for an East Asian wide character.

--- a/src/Text/DocLayout/ANSIFont.hs
+++ b/src/Text/DocLayout/ANSIFont.hs
@@ -12,22 +12,25 @@ module Text.DocLayout.ANSIFont
   , Background(..)
   , (~>)
   , renderFont
+  , renderOSC8
   ) where
 
 import Data.Data (Data)
 import Data.String
+import Data.Text (Text)
 
 data Font = Font
   { ftWeight :: Weight,
     ftShape :: Shape,
     ftUnderline :: Underline,
     ftForeground :: Foreground,
-    ftBackground :: Background
+    ftBackground :: Background,
+    ftLink :: Maybe Text
   }
   deriving (Show, Eq, Read, Data, Ord)
 
 baseFont :: Font
-baseFont = Font Normal Roman ULNone FGDefault BGDefault
+baseFont = Font Normal Roman ULNone FGDefault BGDefault Nothing
 
 data Weight = Normal | Bold deriving (Show, Eq, Read, Data, Ord)
 data Shape = Roman | Italic deriving (Show, Eq, Read, Data, Ord)
@@ -84,3 +87,7 @@ renderFont f
         <> renderSGR (ftForeground f)
         <> renderSGR (ftBackground f)
         <> renderSGR (ftUnderline f)
+
+renderOSC8 :: (Semigroup a, IsString a) => Maybe a -> a
+renderOSC8 Nothing = "\ESC]8;;\ESC\\"
+renderOSC8 (Just t) = "\ESC]8;;" <> t <> "\ESC\\"

--- a/src/Text/DocLayout/Attributed.hs
+++ b/src/Text/DocLayout/Attributed.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
-module Text.DocLayout.Attributed (Attributed(..), Attr(..), fromList, singleton)
+module Text.DocLayout.Attributed (Attributed(..), Attr(..), Link, fromList, singleton)
   where
 
 import Data.String
@@ -11,16 +11,19 @@ import Data.Data (Data, Typeable)
 import GHC.Generics
 import Data.Sequence ((><))
 import qualified Data.Sequence as S
+import Data.Text (Text)
 
-data Attr a = Attr Font a
+type Link = Maybe Text
+
+data Attr a = Attr Link Font a
   deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable,
     Data, Typeable, Generic)
 
 instance Semigroup a => Semigroup (Attr a) where
-  (<>) (Attr f x) (Attr _ y) = Attr f $ x <> y  -- This is arbitrary
+  (<>) (Attr l f x) (Attr _ _ y) = Attr l f $ x <> y  -- This is arbitrary
 
 instance (IsString a, Monoid a) => Monoid (Attr a) where
-  mempty = Attr baseFont (fromString "")
+  mempty = Attr Nothing baseFont (fromString "")
 
 newtype Attributed a = Attributed (S.Seq (Attr a))
   deriving (Show, Read, Eq, Ord, Functor, Foldable, Traversable,
@@ -33,10 +36,10 @@ singleton :: Attr a -> Attributed a
 singleton = Attributed . S.singleton
 
 instance IsString a => IsString (Attr a) where
-  fromString x = Attr baseFont (fromString x)
+  fromString x = Attr Nothing baseFont (fromString x)
 
 instance IsString a => IsString (Attributed a) where
-  fromString x = Attributed $ S.singleton $ Attr baseFont (fromString x)
+  fromString x = Attributed $ S.singleton $ Attr Nothing baseFont (fromString x)
 
 instance Semigroup a => Semigroup (Attributed a) where
   (<>) (Attributed a) (Attributed b) = Attributed $ a >< b

--- a/src/Text/DocLayout/HasChars.hs
+++ b/src/Text/DocLayout/HasChars.hs
@@ -60,19 +60,19 @@ instance HasChars TL.Text where
   build             = B.fromLazyText
 
 instance HasChars a => HasChars (Attr a) where
-  foldrChar f a (Attr _ x) = foldrChar f a x
-  foldlChar f a (Attr _ x) = foldlChar f a x
-  splitLines (Attr f x) = Attr f <$> splitLines x
-  build (Attr _ x) = build x
+  foldrChar f a (Attr _ _ x) = foldrChar f a x
+  foldlChar f a (Attr _ _ x) = foldlChar f a x
+  splitLines (Attr l f x) = Attr l f <$> splitLines x
+  build (Attr _ _ x) = build x
 
 instance (HasChars a) => HasChars (Attributed a) where
   foldrChar _ acc (Attributed S.Empty) = acc
-  foldrChar f acc (Attributed (xs :|> (Attr _ x))) =
+  foldrChar f acc (Attributed (xs :|> (Attr _ _ x))) =
     let l = foldrChar f acc x
         innerFold e a = foldrChar f a e
      in foldr innerFold l xs
   foldlChar _ acc (Attributed S.Empty) = acc
-  foldlChar f acc (Attributed ((Attr _ x) :<| xs)) =
+  foldlChar f acc (Attributed ((Attr _ _ x) :<| xs)) =
     let l = foldlChar f acc x
         innerFold e a = foldlChar f a e
      in foldr innerFold l xs


### PR DESCRIPTION
Few more things as I work in parallel on the ANSI writer, which I think I will be able to send an initial PR for Real Soon Now.

Colors and strikeouts are fairly straightforward. Link support is a little bit more interesting but barely. Both colors and links could get more complicated internally but I don't think I'm setting us up for an external API break.

The `Attr` constructor grows a field for a link target, which is just a `Maybe Text` for the time being. We deem nested links to be illegal, like HTML, and so the rendering state only has to keep track of one link at a time. When rendering to ANSI, we use OSC8 to include the link in the output.

OSC8 links support an "id" parameter which tells terminals to treat discontiguous linked text spans as being "the same" link, for mouseover purposes. Our code could grow to support this.
